### PR TITLE
Readme: Add hwdec warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,13 @@ Potentially interesting parameters:
 - `g=9999999` No keyframes inbetween
 
 ## Run glitcher
+
 ```
 cargo run --release -- -i videos/* |  mpv --no-correct-pts --fps=1000 --no-cache -
 ```
+
+The H.264 stream may crash some GPUs when using hardware decoding.
+Consider to add `--hwdec=no` to your mpv call if you are experiencing problems.
 
 By default the glitcher listens on port 8000 for OSC messages.
 


### PR DESCRIPTION
When trying out h264_glitcher it took just a few seconds to crash my AMD GPU.

I specifically enabled `hwdec` in my `mpv.conf`, so this is completely my fault.. but I'd assume that other people have this enabled as well, so adding a warning and a config flag to the example snippet could spare them *spicy surprises*.